### PR TITLE
Fixed timestamps from Discord Rich Presence when reset timestamps on file change is disabled

### DIFF
--- a/DiscordRPforVSPackage.cs
+++ b/DiscordRPforVSPackage.cs
@@ -171,6 +171,8 @@
                         this.Presence.Timestamps = this.CurrentTimestamps;
                     else if (!Settings.resetTimestamp && !overrideTimestampReset)
                         this.Presence.Timestamps = this.InitialTimestamps;
+                    else if (!Settings.resetTimestamp && overrideTimestampReset)
+                        this.Presence.Timestamps = this.CurrentTimestamps;
 
                     this.CurrentTimestamps = this.Presence.Timestamps;
                 }


### PR DESCRIPTION
I prefer the timestamps to stay unchanged so CurrentTimestamps is assigned to Presence.Timestamps. 